### PR TITLE
Fix issues where -inf's are not properly dealt with. 

### DIFF
--- a/torch_mutual_information/mutual_information_cpu.cpp
+++ b/torch_mutual_information/mutual_information_cpu.cpp
@@ -203,9 +203,15 @@ std::vector<torch::Tensor> mutual_information_backward_cpu(
                   total = p_a[b][s][t],
                   term1_deriv = exp(term1 - total),
                   term2_deriv = 1.0 - term1_deriv,
-                  grad = p_grad_a[b][s][t],
-                  term1_grad = term1_deriv * grad,
-                  term2_grad = term2_deriv * grad;
+                  grad = p_grad_a[b][s][t];
+              scalar_t term1_grad, term2_grad;
+              if (term1_deriv - term1_deriv == 0.0) {
+                term1_grad = term1_deriv * grad;
+                term2_grad = term2_deriv * grad;
+              } else {
+                // could happen if total == -inf
+                term1_grad = term2_grad = 0.0;
+              }
               px_grad_a[b][s - 1][t] = term1_grad;
               p_grad_a[b][s - 1][t] = term1_grad;
               py_grad_a[b][s][t - 1] = term2_grad;

--- a/torch_mutual_information/mutual_information_test.py
+++ b/torch_mutual_information/mutual_information_test.py
@@ -3,6 +3,7 @@
 
 import random
 import torch
+import torch_mutual_information
 from torch_mutual_information import mutual_information_recursion, joint_mutual_information_recursion
 
 
@@ -11,8 +12,8 @@ def test_mutual_information_basic():
 
     for _iter in range(100):
         (B, S, T) = (random.randint(1, 10),
-                     random.randint(1, 200),
-                     random.randint(1, 200))
+                     random.randint(1, 16),
+                     random.randint(1, 500))
         random_px = (random.random() < 0.2)
         random_py = (random.random() < 0.2)
         random_boundary = (random.random() < 0.7)
@@ -50,6 +51,8 @@ def test_mutual_information_basic():
                 if device == torch.device('cpu'):
                     if random_px:
                         px = torch.randn(B, S, T + 1, dtype=dtype).to(device)  # log of an odds ratio
+                        if S > 1 and not random_boundary:
+                            px[:,:,-1:] = float('-inf')
                     else:
                         px = torch.zeros(B, S, T + 1, dtype=dtype).to(device)  # log of an odds ratio
                     # px and py get exponentiated, and then multiplied together up to
@@ -85,8 +88,15 @@ def test_mutual_information_basic():
                 print("m2 = ", m2, ", size = ", m2.shape)
                 print("m3 = ", m3, ", size = ", m3.shape)
 
+                # try:
                 assert torch.allclose(m, m2)
                 assert torch.allclose(m, m3)
+                #except Exception as e:
+                #   torch_mutual_information.mutual_information.DEBUG = True
+                #   m = mutual_information_recursion(px, py, boundary)   # will print debug
+                #   print("px = ", px)
+                #   print("py = ", py)
+                #   raise(e)
 
                 #print("exp(m) = ", m.exp())
 


### PR DESCRIPTION
May not be fully tested.
Simplifies the forward code by removing the "panic" mode and doing everything in log space;
this is slower in the normal case, but since we will probably be dealing with -inf elements a lot, due
to how the pruning code works, it will probably end up being faster after all.